### PR TITLE
Avoid repeated configurations of Ably from being instantiated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -4,8 +4,7 @@ import { Types } from "ably";
 let ably = null;
 
 export function configureAbly(ablyConfigurationObject: string | Types.ClientOptions) {
-    ably = new Ably.Realtime.Promise(ablyConfigurationObject);
-    return ably;
+    return ably || (ably = new Ably.Realtime.Promise(ablyConfigurationObject));
 }
 
 export function assertConfiguration(): Types.RealtimePromise {


### PR DESCRIPTION
Check if ably object in AblyReactHooks has been instantiated before potentially re-instantiating it.