### PR TITLE
Replace ably promises import with default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "1.1.0",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -1,16 +1,16 @@
-import Ably from "ably/promises";
+import Ably from "ably";
 import { Types } from "ably";
 
 let ably = null;
 
 export function configureAbly(ablyConfigurationObject: string | Types.ClientOptions) {
-    return ably || (ably = new Ably.Realtime.Promise(ablyConfigurationObject));
+  return ably || (ably = new Ably.Realtime.Promise(ablyConfigurationObject));
 }
 
 export function assertConfiguration(): Types.RealtimePromise {
-    if (!ably) {
-        throw new Error('Ably not configured - please call configureAbly({ key: "your-api-key", clientId: "someid" });');
-    }
+  if (!ably) {
+    throw new Error('Ably not configured - please call configureAbly({ key: "your-api-key", clientId: "someid" });');
+  }
 
-    return ably;
+  return ably;
 }


### PR DESCRIPTION
Owen has confirmed that there's a [known bug](https://ably-real-time.slack.com/archives/C017C5EPYG0/p1637318700006800) with Ably types for the `RealtimeChannel` object when using the promise style import. The `ably-js` readme will be updated soon to show that the promise style import is not required and we can use the promise API by just using the promise constructor i.e. `Ably.Realtime.Promise(options)`. 

 I'm going to link to this project from the async/await post, so this needed to be fixed to show recommended usage.