### PR TITLE
Do not subscribe if channel empty string

### DIFF
--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -22,6 +22,9 @@ export function useChannel(channelName: string, ...channelSubscriptionArguments:
     }
 
     const useEffectHook = () => {
+        if(!channel) {
+            return
+        }
         onMount();
         return () => { onUnmount(); };
     };


### PR DESCRIPTION
I was thinking of some way to conditionally subscribe, but the hook does not allow for that. As a work-around, I would like for the useChannel hook to subscribe only when the channel name is a truthy value.