### PR TITLE
Detach channels when components are unmounted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -18,7 +18,8 @@ export function useChannel(channelName: string, ...channelSubscriptionArguments:
     }
 
     const onUnmount = () => {
-        channel.unsubscribe.apply(channel, channelSubscriptionArguments);
+        channel.unsubscribe.apply(channel, channelSubscriptionArguments);        
+        channel.detach();
     }
 
     const useEffectHook = () => {


### PR DESCRIPTION
This change adds a call to detach from channels during component unmount to stop unmounted channels from receiving messages that are never rendered in a react component.

The [Ably docs](https://ably.com/docs/realtime/channels) state (emphasis mine):

"...it is important to note that if a client subscribes to and then unsubscribes from a channel, the client remains attached. **The client will continue to be sent published messages until they detach from the channel.**"

This PR reflects this, and makes sure that after a react component unmounts, any instances of `useChannel` and the subsequent subscriptions that are created, are correctly detached to prevent react apps accidentally using too much of their messaging quotas.

Version number bumped to match.
