### PR TITLE
Improved channel auto-detach behaviour when components mount/unmount.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/react-hooks",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -24,10 +24,10 @@ export function usePresence<T = any>(channelNameOrNameAndOptions: ChannelParamet
     const [presenceData, updatePresenceData] = useState([]) as [Array<PresenceMessage<T>>, UseStatePresenceUpdate];
 
     const updatePresence = async (message?: Types.PresenceMessage) => {
-        onPresenceUpdated?.call(this, message);
-
         const snapshot = await channel.presence.get();
         updatePresenceData(snapshot);
+        
+        onPresenceUpdated?.call(this, message);
     }
 
     const onMount = async () => {


### PR DESCRIPTION
There's an edge case in the existing auto-detach behaviour in cases where React rapidly unmounts and remounts a component that calls useChannel.

Auto-detaching is a message-limit-saving optimisation that disconnects from the Ably websockets, so instead of just detaching on unmount, in this implementation we set a 2500ms timer, and if the number of channel listeners is still 0 (which it should always be if unmount was executed without a subsequent mount request) - we *then* detach from the websocket.

This rapid remounting was the source of a few subtle bugs where variables tracked with useState were not being correctly respected due to exceptions being thrown.