### PR TITLE
Add support for commonJS import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/react-hooks",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.27"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/react-hooks",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,20 @@
   "name": "@ably-labs/react-hooks",
   "version": "2.0.9",
   "description": "",
-  "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "start": "npx vite serve",
     "test": "vitest run",
-    "ci": "npm run test && tsc"
+    "ci": "npm run test && npm run build",
+    "build": "npm run build:cjs && npm run build:mjs",
+    "build:mjs": "tsc --project tsconfig.mjs.json && cp res/package.mjs.json dist/mjs/package.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json && cp res/package.cjs.json dist/cjs/package.json"
+  },
+  "exports": {
+    "import": "./dist/mjs/index.js",
+    "require": "./dist/cjs/index.js"
   },
   "repository": {
     "type": "git",

--- a/res/package.cjs.json
+++ b/res/package.cjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/res/package.mjs.json
+++ b/res/package.mjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "./src/**/*.test.tsx",
+    "./src/fakes/**/*.ts"
+  ],
+  "compilerOptions": {
+    "target": "es6",
+    "rootDir": "./src",
+    "sourceMap": true,
+    "strict": false,
+    "esModuleInterop": true,
+    "declaration": true,
+    "moduleResolution": "node",
+    "skipLibCheck": true,
+    "allowJs": true,
+    "jsx": "react-jsx",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "types": [
+      "vitest/globals"
+    ]
+  }
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,32 +1,7 @@
 {
-    "include": [
-        "./src/**/*.ts"
-    ],
-    "exclude": [
-        "./src/**/*.test.tsx",
-        "./src/fakes/**/*.ts"
-    ],
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
         "module": "CommonJS",
-        "target": "es6",
         "outDir": "dist/cjs",
-        "rootDir": "./src",
-        "sourceMap": true,
-        "strict": false,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "declaration": true,
-        "moduleResolution": "node",
-        "skipLibCheck": true,
-        "allowJs": true,
-        "jsx": "react-jsx",
-        "lib": [
-            "DOM",
-            "DOM.Iterable",
-            "ESNext"
-        ],
-        "types": [
-            "vitest/globals"
-        ]
     }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -7,18 +7,19 @@
         "./src/fakes/**/*.ts"
     ],
     "compilerOptions": {
-        "module": "ES6",
+        "module": "CommonJS",
         "target": "es6",
-        "outDir": "dist",
+        "outDir": "dist/cjs",
         "rootDir": "./src",
         "sourceMap": true,
         "strict": false,
         "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
         "declaration": true,
         "moduleResolution": "node",
         "skipLibCheck": true,
         "allowJs": true,
-        "jsx": "react-jsx",    
+        "jsx": "react-jsx",
         "lib": [
             "DOM",
             "DOM.Iterable",

--- a/tsconfig.mjs.json
+++ b/tsconfig.mjs.json
@@ -1,31 +1,7 @@
 {
-    "include": [
-        "./src/**/*.ts"
-    ],
-    "exclude": [
-        "./src/**/*.test.tsx",
-        "./src/fakes/**/*.ts"
-    ],
+    "extends": "./tsconfig.base.json",
     "compilerOptions": {
         "module": "ES6",
-        "target": "es6",
         "outDir": "dist/mjs",
-        "rootDir": "./src",
-        "sourceMap": true,
-        "strict": false,
-        "esModuleInterop": true,
-        "declaration": true,
-        "moduleResolution": "node",
-        "skipLibCheck": true,
-        "allowJs": true,
-        "jsx": "react-jsx",
-        "lib": [
-            "DOM",
-            "DOM.Iterable",
-            "ESNext"
-        ],
-        "types": [
-            "vitest/globals"
-        ]
     }
 }

--- a/tsconfig.mjs.json
+++ b/tsconfig.mjs.json
@@ -1,0 +1,31 @@
+{
+    "include": [
+        "./src/**/*.ts"
+    ],
+    "exclude": [
+        "./src/**/*.test.tsx",
+        "./src/fakes/**/*.ts"
+    ],
+    "compilerOptions": {
+        "module": "ES6",
+        "target": "es6",
+        "outDir": "dist/mjs",
+        "rootDir": "./src",
+        "sourceMap": true,
+        "strict": false,
+        "esModuleInterop": true,
+        "declaration": true,
+        "moduleResolution": "node",
+        "skipLibCheck": true,
+        "allowJs": true,
+        "jsx": "react-jsx",
+        "lib": [
+            "DOM",
+            "DOM.Iterable",
+            "ESNext"
+        ],
+        "types": [
+            "vitest/globals"
+        ]
+    }
+}


### PR DESCRIPTION
This PR builds the library with both CJS and ESM support and configures the package to be able to support both. 