### PR TITLE
Fix incorrect typescript types path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/react-hooks",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.27"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/mjs/index.d.ts",
   "scripts": {
     "start": "npx vite serve",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",


### PR DESCRIPTION
Fixes #22 

The `types` path in package.json is incorrect following the hybrid package update.