### PR TITLE
feat: implement ably-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,9 @@ This API key will be loaded by the vite dev server at build time.
 You can run the `unit tests` by running `npm run test` in the terminal.
 
 You can build the published artefacts by running `npm run ci` in the terminal. The node module is distrubted as an ES6 module, and requires consumers to be able to import modules in their react apps. The test application and unit tests are excluded from the generated `dist` folder to prevent confusion at runtime.
+
+### Release process
+
+- Release happens on push to `main` from the [`npm-publish`](./.github/workflows/npm-publish.yml) workflow.
+- If more than one feature branch is needed, use an integration branch to avoid pushing to `main` during development.
+- Be sure to update the version in [`package.json`](./package.json), [`package-lock.json`](./package-lock.json), and [`AblyReactHooks.ts`](./src/AblyReactHooks.ts) before merging to `main`

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -4,14 +4,30 @@ import { Types } from "ably";
 export type ChannelNameAndOptions = { channelName: string; options?: Types.ChannelOptions; realtime?: Types.RealtimePromise }
 export type ChannelParameters =  string | ChannelNameAndOptions;
 
-let sdkInstance = null;
+const version = "2.1.0"
+
+let sdkInstance: Realtime | null = null;
+
+export class Realtime extends Ably.Realtime.Promise {
+  constructor(options: string | Types.ClientOptions) {
+    if (typeof options === "string") {
+      options = {
+        key: options,
+      } as Types.ClientOptions;
+    }
+
+    (options as any).agents = [`react-hooks/${version}`]
+
+    super(options);
+  }
+}
 
 export function provideSdkInstance(ablyInstance: Types.RealtimePromise) {
     sdkInstance = ablyInstance;
 }
 
 export function configureAbly(ablyConfigurationObject: string | Types.ClientOptions) {
-  return sdkInstance || (sdkInstance = new Ably.Realtime.Promise(ablyConfigurationObject));
+  return sdkInstance || (sdkInstance = new Realtime(ablyConfigurationObject));
 }
 
 export function assertConfiguration(): Types.RealtimePromise {
@@ -21,5 +37,3 @@ export function assertConfiguration(): Types.RealtimePromise {
 
   return sdkInstance;
 }
-
-export const Realtime = Ably.Realtime.Promise;


### PR DESCRIPTION
Adds a second source of truth for lib version because there isn't a sensible way to source version from package.json when our build toolchain is just the typescript compiler :/
