### PR TITLE
New release process

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,9 +1,11 @@
 name: Build and test
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,7 @@
-name: Release node package
+name: Release NPM package
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.md
+  workflow_dispatch:
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+## Contributing
+
+This repository is configured to execute using Vite - which will load a sample web app that acts as a simple test harness for the hooks.
+
+You can run the dev server from the terminal using:
+
+```bash
+npm run start
+```
+
+You'll need to provide an API key for the sample to work (or you'll just get a white page and some errors in the console). To do this, create the file `./src/.env` and add the following line:
+
+```.env
+VITE_ABLY_API_KEY=<your-api-key>
+```
+
+This API key will be loaded by the vite dev server at build time.
+
+You can run the `unit tests` by running `npm run test` in the terminal.
+
+You can build the published artefacts by running `npm run ci` in the terminal. The node module is distrubted as an ES6 module, and requires consumers to be able to import modules in their react apps. The test application and unit tests are excluded from the generated `dist` folder to prevent confusion at runtime.
+
+### Release process
+
+- Release happens on push to `main` from the [`npm-publish`](./.github/workflows/npm-publish.yml) workflow.
+- If more than one feature branch is needed, use an integration branch to avoid pushing to `main` during development.
+- Be sure to update the version in [`package.json`](./package.json), [`package-lock.json`](./package-lock.json), and [`AblyReactHooks.ts`](./src/AblyReactHooks.ts) before merging to `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ You can build the published artefacts by running `npm run ci` in the terminal. T
 
 ### Release process
 
-- Release happens on push to `main` from the [`npm-publish`](./.github/workflows/npm-publish.yml) workflow.
-- If more than one feature branch is needed, use an integration branch to avoid pushing to `main` during development.
-- Be sure to update the version in [`package.json`](./package.json), [`package-lock.json`](./package-lock.json), and [`AblyReactHooks.ts`](./src/AblyReactHooks.ts) before merging to `main`
+1. Create a new branch for the release, for example `release/1.2.3`
+2. Update the CHANGELOG.md with any customer-affecting changes since the last release and add this to the git index
+3. Run `npm version <VERSION_NUMBER> --no-git-tag-version` with the new version and add the changes to the git index
+4. Create a PR for the release branch
+5. Once the release PR is landed to the `main` branch, checkout the `main` branch locally (remember to pull the remote changes)
+6. Run `git tag <VERSION_NUMBER>` with the new version and push the tag to git
+7. Run `npm publish .` (should require OTP) - publishes to NPM
+8. Run the GitHub action "Release NPM package" on the main branch
+9. Visit https://github.com/ably/ably-js/tags and add release notes to the release (generally you can just copy the notes you added to the CHANGELOG)

--- a/README.md
+++ b/README.md
@@ -250,33 +250,3 @@ usePresence({ channelName: "your-channel-name", realtime: realtime }, (presenceU
     ...
 })
 ```
-
----
-
-## Developer Notes
-
-This repository is configured to execute using Vite - which will load a sample web app that acts as a simple test harness for the hooks.
-
-You can run the dev server from the terminal using:
-
-```bash
-npm run start
-```
-
-You'll need to provide an API key for the sample to work (or you'll just get a white page and some errors in the console). To do this, create the file `./src/.env` and add the following line:
-
-```.env
-VITE_ABLY_API_KEY=<your-api-key>
-```
-
-This API key will be loaded by the vite dev server at build time.
-
-You can run the `unit tests` by running `npm run test` in the terminal.
-
-You can build the published artefacts by running `npm run ci` in the terminal. The node module is distrubted as an ES6 module, and requires consumers to be able to import modules in their react apps. The test application and unit tests are excluded from the generated `dist` folder to prevent confusion at runtime.
-
-### Release process
-
-- Release happens on push to `main` from the [`npm-publish`](./.github/workflows/npm-publish.yml) workflow.
-- If more than one feature branch is needed, use an integration branch to avoid pushing to `main` during development.
-- Be sure to update the version in [`package.json`](./package.json), [`package-lock.json`](./package-lock.json), and [`AblyReactHooks.ts`](./src/AblyReactHooks.ts) before merging to `main`


### PR DESCRIPTION
Changes the release process to address a couple of issues:
- Currently, pushing to `main` runs the NPM publish workflow. It's quite easy to forget about this and accidentally trigger this workflow.
- Currently we don't have a CHANGELOG, tags, or GitHub releases which makes it hard to inspect the source code of a particular release or understand what's changed between releases.

This PR changes the release process to be more aligned with our other SDK repos by adding tags, changelog updates, release PRs, and GitHub releases. It also amends the release workflow to be triggered manually as part of the release process in order to avoid any situation where developers may unintentionally trigger an NPM release.