### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## [v2.1.1](https://github.com/ably-labs/react-hooks/tree/v2.1.1)
+
+[Full Changelog](https://github.com/ably-labs/react-hooks/compare/934c32cb9af7e0b0aa4732c373294c632423f584...v2.1.1)
+
+- fix: wrap `updateStatus` in `useCallback` [\#37](https://github.com/ably-labs/react-hooks/pull/37)
+- fix: correct ably-agent format [\#34](https://github.com/ably-labs/react-hooks/pull/34)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ably-labs/react-hooks",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "ably": "^1.2.27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ably-labs/react-hooks",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -4,7 +4,7 @@ import { Types } from "ably";
 export type ChannelNameAndOptions = { channelName: string; options?: Types.ChannelOptions; realtime?: Types.RealtimePromise }
 export type ChannelParameters =  string | ChannelNameAndOptions;
 
-const version = "2.1.0"
+const version = "2.1.1"
 
 let sdkInstance: Realtime | null = null;
 


### PR DESCRIPTION
- adds a changelog for the first time
- since no tags exist for previous versions, the diff link uses the full commit SHA of the last released commit