### PR TITLE
feat!: channel/connection error handling APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ root.render(
 Once you've done this, you can use the `hooks` in your code. The simplest example is as follows:
 
 ```javascript
-const [channel] = useChannel("your-channel-name", (message) => {
+const { channel } = useChannel("your-channel-name", (message) => {
     console.log(message);
 });
 ```
@@ -116,7 +116,7 @@ Every time a message is sent to `your-channel-name` it'll be logged to the conso
 The useChannel hook lets you subscribe to a channel and receive messages from it.
 
 ```javascript
-const [channel, ably] = useChannel("your-channel-name", (message) => {
+const { channel, ably } = useChannel("your-channel-name", (message) => {
     console.log(message);
 });
 ```
@@ -127,7 +127,7 @@ const [channel, ably] = useChannel("your-channel-name", (message) => {
 
 ```javascript
 const [messages, updateMessages] = useState([]);
-const [channel] = useChannel("your-channel-name", (message) => {
+const { channel } = useChannel("your-channel-name", (message) => {
     updateMessages((prev) => [...prev, message]);
 });
 
@@ -138,7 +138,7 @@ const messagePreviews = messages.map((msg, index) => <li key={index}>{msg.data.s
 `useChannel` supports all of the parameter combinations of a regular call to `channel.subscribe`, so you can filter the messages you subscribe to by providing a `message type` to the `useChannel` function:
 
 ```javascript
-const [channel] = useChannel("your-channel-name", "test-message", (message) => {
+const { channel } = useChannel("your-channel-name", "test-message", (message) => {
     console.log(message); // Only logs messages sent using the `test-message` message type
 });
 ```
@@ -154,7 +154,7 @@ Because we're returning the channel instance, and Ably SDK instance from our `us
 For example, you could retrieve history like this:
 
 ```javascript
-const [channel] = useChannel("your-channel-name", (message) => {
+const { channel } = useChannel("your-channel-name", (message) => {
     console.log(message);
 });
 
@@ -168,7 +168,7 @@ It's also worth highlighting that the `useChannel` hook supports all of the addi
 This means you can use features like `rewind`:
 
 ```javascript
-const [channel] = useChannel("[?rewind=100]your-channel-name", (message) => {
+const { channel } = useChannel("[?rewind=100]your-channel-name", (message) => {
     // This call will rewind 100 messages
     console.log(message);
 });
@@ -177,7 +177,7 @@ const [channel] = useChannel("[?rewind=100]your-channel-name", (message) => {
 We support providing [ChannelOptions](https://ably.com/docs/api/realtime-sdk/types#channel-options) to the `useChannel` hook:
 
 ```javascript
-const [channel] = useChannel({ channelName: "your-channel-name", options: { ... } }, (message) => {
+const { channel } = useChannel({ channelName: "your-channel-name", options: { ... } }, (message) => {
     ...
 });
 ```
@@ -205,7 +205,7 @@ The usePresence hook lets you subscribe to presence events on a channel - this w
 **Please note** that fetching present members is executed as an effect, so it'll load in *after* your component renders for the first time.
 
 ```javascript
-const [presenceData, updateStatus] = usePresence("your-channel-name");
+const { presenceData, updateStatus } = usePresence("your-channel-name");
 
 // Convert presence data to list items to render    
 const peers = presenceData.map((msg, index) => <li key={index}>{msg.clientId}: {msg.data}</li>);
@@ -216,7 +216,7 @@ const peers = presenceData.map((msg, index) => <li key={index}>{msg.clientId}: {
 You can optionally provide a string when you `usePresence` to set an initial `presence data` string.
 
 ```javascript
-const [presenceData, updateStatus] = usePresence("your-channel-name", "initial state");
+const { presenceData, updateStatus } = usePresence("your-channel-name", "initial state");
 
 // The `updateStatus` function can be used to update the presence data for the current client
 updateStatus("new status");
@@ -227,7 +227,7 @@ The new state will be sent to the channel, and any other clients subscribed to t
 If you don't want to use the `presenceData` returned from usePresence, you can configure a callback
 
 ```javascript
-const [_, updateStatus] = usePresence("your-channel-name", "initial state", (presenceUpdate) => {
+const { updateStatus } = usePresence("your-channel-name", "initial state", (presenceUpdate) => {
     console.log(presenceUpdate);
 });
 ```
@@ -245,7 +245,7 @@ const TypedUsePresenceComponent = () => {
     // In this example MyPresenceType will be checked - if omitted, the shape of the initial 
     // value will be used ...and if that's omitted, `any` will be the default.
 
-    const [val] = usePresence<MyPresenceType>("testChannelName", { foo: "bar" });
+    const { val } = usePresence<MyPresenceType>("testChannelName", { foo: "bar" });
 
     return (
         <div role='presence'>

--- a/README.md
+++ b/README.md
@@ -309,6 +309,34 @@ const client = useAbly();
 client.authorize();
 ```
 
+### Error Handling
+
+When using the Ably react hooks, your Ably client may encounter a variety of errors, for example if it doesn't have permissions to attach to a channel it may encounter a channel error, or if it loses connection from the Ably network it may encounter a connection error.
+
+To allow you to handle these errors, the `useChannel` and `usePresence` hooks return connection and channel errors so that you can react to them in your components: 
+
+```jsx
+const { connectionError, channelError } = useChannel('my_channel', messageHandler);
+
+if (connectionError) {
+  // TODO: handle connection errors
+} else if (channelError) {
+  // TODO: handle channel errors
+} else {
+  return <AblyChannelComponent />
+}
+```
+
+Alternatively, you can also pass callbacks to the hooks to be called when the client encounters an error:
+
+```js
+useChannel({
+  channelName: 'my_channel',
+  onConnectionError: (err) => { /* handle connection error */ },
+  onChannelError: (err) => { /* handle channel error */ },
+}, messageHandler);
+```
+
 ### Usage with multiple clients
 
 If you need to use multiple Ably clients on the same page, the easiest way to do so is to keep your clients in separate `AblyProvider` components. However, if you need to nest `AblyProvider`s, you can pass a string id for each client as a prop to the provider.

--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -11,11 +11,11 @@ import './App.css';
 
 function App() {
     const [messages, updateMessages] = useState<Types.Message[]>([]);
-    const [channel, ably] = useChannel('your-channel-name', (message) => {
+    const { channel, ably } = useChannel('your-channel-name', (message) => {
         updateMessages((prev) => [...prev, message]);
     });
 
-    const [presenceData, updateStatus] = usePresence(
+    const { presenceData, updateStatus } = usePresence(
         'your-channel-name',
         { foo: 'bar' },
         (update) => {

--- a/sample-app/src/App.tsx
+++ b/sample-app/src/App.tsx
@@ -6,6 +6,7 @@ import {
     usePresence,
     useConnectionStateListener,
     useChannelStateListener,
+    useAbly,
 } from '../../src/index';
 import './App.css';
 
@@ -23,16 +24,22 @@ function App() {
         }
     );
 
-    const [connectionState, setConnectionState] = useState(ably.connection.state);
+    const [connectionState, setConnectionState] = useState(
+        ably.connection.state
+    );
 
     useConnectionStateListener((stateChange) => {
-      setConnectionState(stateChange.current)
+        setConnectionState(stateChange.current);
     });
 
     const [ablyErr, setAblyErr] = useState('');
     const [channelState, setChannelState] = useState(channel.state);
-    const [previousChannelState, setPreviousChannelState] = useState<undefined | Types.ChannelState>();
-    const [channelStateReason, setChannelStateReason] = useState<undefined | Types.ErrorInfo>();
+    const [previousChannelState, setPreviousChannelState] = useState<
+        undefined | Types.ChannelState
+    >();
+    const [channelStateReason, setChannelStateReason] = useState<
+        undefined | Types.ErrorInfo
+    >();
 
     useChannelStateListener('your-channel-name', 'detached', (stateChange) => {
         setAblyErr(JSON.stringify(stateChange.reason));
@@ -72,31 +79,64 @@ function App() {
                 </button>
             </div>
 
-            <h2>Connection State</h2>
-            <div>{connectionState}</div>
+            <div style={{ position: 'fixed', width: '250px' }}>
+                <ConnectionState />
+            </div>
+            <div style={{marginLeft: '250px'}}>
+                <h2>Channel detach</h2>
+                <button onClick={() => channel.detach()}>Detach</button>
+                <button onClick={() => ably.close()}>Close</button>
 
-            <h2>Channel detach</h2>
-            <button onClick={() => channel.detach()}>Detach</button>
-            <button onClick={() => ably.close()}>Close</button>
+                <h2>Channel State</h2>
+                <h3>Current</h3>
+                <div>{channelState}</div>
+                <h3>Previous</h3>
+                <div>{previousChannelState}</div>
+                <h3>Reason</h3>
+                <div>{JSON.stringify(channelStateReason)}</div>
 
-            <h2>Channel State</h2>
-            <h3>Current</h3>
-            <div>{channelState}</div>
-            <h3>Previous</h3>
-            <div>{previousChannelState}</div>
-            <h3>Reason</h3>
-            <div>{JSON.stringify(channelStateReason)}</div>
+                <h2>Ably error</h2>
+                <h3>Reason</h3>
+                <div>{ablyErr}</div>
 
-            <h2>Ably error</h2>
-            <h3>Reason</h3>
-            <div>{ablyErr}</div>
+                <h2>Messages</h2>
+                <ul>{messagePreviews}</ul>
 
-            <h2>Messages</h2>
-            <ul>{messagePreviews}</ul>
-
-            <h2>Present Clients</h2>
-            <ul>{presentClients}</ul>
+                <h2>Present Clients</h2>
+                <ul>{presentClients}</ul>
+            </div>
         </div>
+    );
+}
+
+function ConnectionState() {
+    const ably = useAbly();
+    const [connectionState, setConnectionState] = useState(
+        ably.connection.state
+    );
+    const [connectionError, setConnectionError] =
+        useState<Types.ErrorInfo | null>(null);
+    useConnectionStateListener((stateChange) => {
+        console.log(stateChange);
+        setConnectionState(stateChange.current);
+        if (stateChange.reason) {
+            setConnectionError(stateChange.reason);
+        }
+    });
+
+    return (
+        <>
+            <p>Connection State = &apos;{connectionState}&apos;</p>
+            {connectionError && (
+                <p>
+                    Connection Error ={' '}
+                    <a href={(connectionError as any).href}>
+                        {connectionError.message} ({connectionError.code}{' '}
+                        {connectionError.statusCode})
+                    </a>
+                </p>
+            )}
+        </>
     );
 }
 

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -6,6 +6,8 @@ export type ChannelNameAndOptions = {
     id?: string;
     realtime?: Types.RealtimePromise;
     subscribeOnly?: boolean;
+    onConnectionError?: (error: Types.ErrorInfo) => unknown;
+    onChannelError?: (error: Types.ErrorInfo) => unknown;
 };
 
 export type ChannelNameAndId = {

--- a/src/hooks/useChannel.test.tsx
+++ b/src/hooks/useChannel.test.tsx
@@ -98,10 +98,13 @@ describe('useChannel', () => {
 
 const UseChannelComponentMultipleClients = ({ client1, client2 }) => {
     const [messages, updateMessages] = useState<Types.Message[]>([]);
-    const [channel1] = useChannel({ channelName: 'blah' }, (message) => {
-        updateMessages((prev) => [...prev, message]);
-    });
-    const [channel2] = useChannel(
+    const { channel: channel1 } = useChannel(
+        { channelName: 'blah' },
+        (message) => {
+            updateMessages((prev) => [...prev, message]);
+        }
+    );
+    const { channel: channel2 } = useChannel(
         { channelName: 'bleh', id: 'otherClient' },
         (message) => {
             updateMessages((prev) => [...prev, message]);
@@ -117,7 +120,7 @@ const UseChannelComponentMultipleClients = ({ client1, client2 }) => {
 
 const UseChannelComponent = () => {
     const [messages, updateMessages] = useState<Types.Message[]>([]);
-    const [channel, ably] = useChannel('blah', (message) => {
+    const { channel, ably } = useChannel('blah', (message) => {
         updateMessages((prev) => [...prev, message]);
     });
 

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -6,7 +6,7 @@ import { useAbly } from './useAbly';
 export type AblyMessageCallback = (message: Types.Message) => void;
 export type ChannelAndClient = [
     channel: Types.RealtimeChannelPromise,
-    ably: Types.RealtimePromise,
+    ably: Types.RealtimePromise
 ];
 
 export function useChannel(
@@ -37,7 +37,6 @@ export function useChannel(
         () => ably.channels.get(channelName, channelOptionsRef.current),
         [channelName]
     );
-
     const onMount = async () => {
         await channel.subscribe.apply(channel, channelSubscriptionArguments);
     };
@@ -71,7 +70,7 @@ export function useChannel(
         };
     };
 
-    useEffect(useEffectHook, [channelName]);
+    useEffect(useEffectHook, [channelHookOptions.channelName]);
 
     return [channel, ably];
 }

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -1,13 +1,18 @@
 import { Types } from 'ably';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly';
+import { useConnectionStateListener } from './useConnectionStateListener';
+import { useChannelStateListener } from './useChannelStateListener';
+import { useStateErrors } from './useStateErrors';
 
 export type AblyMessageCallback = (message: Types.Message) => void;
 
 export interface ChannelResult {
     channel: Types.RealtimeChannelPromise;
     ably: Types.RealtimePromise;
+    connectionError: Types.ErrorInfo | null;
+    channelError: Types.ErrorInfo | null;
 }
 
 export function useChannel(
@@ -38,6 +43,10 @@ export function useChannel(
         () => ably.channels.get(channelName, channelOptionsRef.current),
         [channelName]
     );
+
+    const { connectionError, channelError } =
+        useStateErrors(channelHookOptions);
+
     const onMount = async () => {
         await channel.subscribe.apply(channel, channelSubscriptionArguments);
     };
@@ -73,5 +82,5 @@ export function useChannel(
 
     useEffect(useEffectHook, [channelHookOptions.channelName]);
 
-    return { channel, ably };
+    return { channel, ably, connectionError, channelError };
 }

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -4,25 +4,26 @@ import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly';
 
 export type AblyMessageCallback = (message: Types.Message) => void;
-export type ChannelAndClient = [
-    channel: Types.RealtimeChannelPromise,
-    ably: Types.RealtimePromise
-];
+
+export interface ChannelResult {
+    channel: Types.RealtimeChannelPromise;
+    ably: Types.RealtimePromise;
+}
 
 export function useChannel(
     channelNameOrNameAndOptions: ChannelParameters,
     callbackOnMessage: AblyMessageCallback
-): ChannelAndClient;
+): ChannelResult;
 export function useChannel(
     channelNameOrNameAndOptions: ChannelParameters,
     event: string,
     callbackOnMessage: AblyMessageCallback
-): ChannelAndClient;
+): ChannelResult;
 
 export function useChannel(
     channelNameOrNameAndOptions: ChannelParameters,
     ...channelSubscriptionArguments: any[]
-): ChannelAndClient {
+): ChannelResult {
     const channelHookOptions =
         typeof channelNameOrNameAndOptions === 'object'
             ? channelNameOrNameAndOptions
@@ -72,5 +73,5 @@ export function useChannel(
 
     useEffect(useEffectHook, [channelHookOptions.channelName]);
 
-    return [channel, ably];
+    return { channel, ably };
 }

--- a/src/hooks/useChannelStateListener.ts
+++ b/src/hooks/useChannelStateListener.ts
@@ -12,7 +12,7 @@ export function useChannelStateListener(
 );
 
 export function useChannelStateListener(
-    options: ChannelNameAndId,
+    options: ChannelNameAndId | string,
     state?: Types.ChannelState | Types.ChannelState[],
     listener?: ChannelStateListener
 );

--- a/src/hooks/useChannelStateListener.ts
+++ b/src/hooks/useChannelStateListener.ts
@@ -28,7 +28,7 @@ export function useChannelStateListener(
     const channelName =
         typeof channelNameOrNameAndId === 'string'
             ? channelNameOrNameAndId
-            : channelNameOrNameAndId.id;
+            : channelNameOrNameAndId.channelName;
     const id = (channelNameOrNameAndId as ChannelNameAndId)?.id;
 
     const ably = useAbly(id);

--- a/src/hooks/usePresence.test.tsx
+++ b/src/hooks/usePresence.test.tsx
@@ -132,9 +132,9 @@ describe('usePresence', () => {
 });
 
 const UsePresenceComponent = () => {
-    const [val, update] = usePresence(testChannelName, 'bar');
+    const { presenceData, updateStatus } = usePresence(testChannelName, 'bar');
 
-    const presentUsers = val.map((presence, index) => {
+    const presentUsers = presenceData.map((presence, index) => {
         return (
             <li key={index}>
                 {presence.clientId} - {JSON.stringify(presence)}
@@ -146,7 +146,7 @@ const UsePresenceComponent = () => {
         <>
             <button
                 onClick={() => {
-                    update('baz');
+                    updateStatus('baz');
                 }}
             >
                 Update
@@ -157,11 +157,11 @@ const UsePresenceComponent = () => {
 };
 
 const UsePresenceComponentMultipleClients = ({ client1, client2 }) => {
-    const [val1, update1] = usePresence(
+    const { presenceData: val1, updateStatus: update1 } = usePresence(
         { channelName: testChannelName },
         'foo'
     );
-    const [val2, update2] = usePresence(
+    const { presenceData: val2, updateStatus: update2 } = usePresence(
         { channelName: testChannelName, id: 'otherClient' },
         'bar'
     );
@@ -194,11 +194,11 @@ interface MyPresenceType {
 }
 
 const TypedUsePresenceComponent = () => {
-    const [val] = usePresence<MyPresenceType>('testChannelName', {
+    const { presenceData } = usePresence<MyPresenceType>('testChannelName', {
         foo: 'bar',
     });
 
-    return <div role="presence">{JSON.stringify(val)}</div>;
+    return <div role="presence">{JSON.stringify(presenceData)}</div>;
 };
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -3,10 +3,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
 
-export type PresenceDataAndPresenceUpdateFunction<T> = [
-    presenceData: PresenceMessage<T>[],
-    updateStatus: (messageOrPresenceObject: T) => void
-];
+export interface PresenceResult<T> {
+    presenceData: PresenceMessage<T>[];
+    updateStatus: (messageOrPresenceObject: T) => void;
+}
 
 export type OnPresenceMessageReceived<T> = (
     presenceData: PresenceMessage<T>
@@ -19,7 +19,7 @@ export function usePresence<T = any>(
     channelNameOrNameAndOptions: ChannelParameters,
     messageOrPresenceObject?: T,
     onPresenceUpdated?: OnPresenceMessageReceived<T>
-): PresenceDataAndPresenceUpdateFunction<T> {
+): PresenceResult<T> {
     const params =
         typeof channelNameOrNameAndOptions === 'object'
             ? channelNameOrNameAndOptions
@@ -91,7 +91,7 @@ export function usePresence<T = any>(
         [channel]
     );
 
-    return [presenceData, updateStatus];
+    return { presenceData, updateStatus };
 }
 
 interface PresenceMessage<T = any> {

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -2,10 +2,13 @@ import { Types } from 'ably';
 import { useCallback, useEffect, useState } from 'react';
 import { ChannelParameters } from '../AblyReactHooks.js';
 import { useAbly } from './useAbly.js';
+import { useStateErrors } from './useStateErrors';
 
 export interface PresenceResult<T> {
     presenceData: PresenceMessage<T>[];
     updateStatus: (messageOrPresenceObject: T) => void;
+    connectionError: Types.ErrorInfo | null;
+    channelError: Types.ErrorInfo | null;
 }
 
 export type OnPresenceMessageReceived<T> = (
@@ -33,6 +36,8 @@ export function usePresence<T = any>(
             : params.subscribeOnly;
 
     const channel = ably.channels.get(params.channelName, params.options);
+
+    const { connectionError, channelError } = useStateErrors(params);
 
     const [presenceData, updatePresenceData] = useState<
         Array<PresenceMessage<T>>
@@ -91,7 +96,7 @@ export function usePresence<T = any>(
         [channel]
     );
 
-    return { presenceData, updateStatus };
+    return { presenceData, updateStatus, connectionError, channelError };
 }
 
 interface PresenceMessage<T = any> {

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -5,7 +5,7 @@ import { useAbly } from './useAbly.js';
 
 export type PresenceDataAndPresenceUpdateFunction<T> = [
     presenceData: PresenceMessage<T>[],
-    updateStatus: (messageOrPresenceObject: T) => void,
+    updateStatus: (messageOrPresenceObject: T) => void
 ];
 
 export type OnPresenceMessageReceived<T> = (
@@ -20,34 +20,23 @@ export function usePresence<T = any>(
     messageOrPresenceObject?: T,
     onPresenceUpdated?: OnPresenceMessageReceived<T>
 ): PresenceDataAndPresenceUpdateFunction<T> {
-    const ably = useAbly(
+    const params =
         typeof channelNameOrNameAndOptions === 'object'
-            ? channelNameOrNameAndOptions.id
-            : undefined
-    );
-
-    const channelName =
-        typeof channelNameOrNameAndOptions === 'string'
             ? channelNameOrNameAndOptions
-            : channelNameOrNameAndOptions.channelName;
+            : { channelName: channelNameOrNameAndOptions };
 
-    const channel =
-        typeof channelNameOrNameAndOptions === 'string'
-            ? ably.channels.get(channelName)
-            : ably.channels.get(
-                  channelName,
-                  channelNameOrNameAndOptions.options
-              );
+    const ably = useAbly(params.id);
 
     const subscribeOnly =
         typeof channelNameOrNameAndOptions === 'string'
             ? false
-            : channelNameOrNameAndOptions.subscribeOnly;
+            : params.subscribeOnly;
 
-    const [presenceData, updatePresenceData] = useState([]) as [
-        Array<PresenceMessage<T>>,
-        UseStatePresenceUpdate,
-    ];
+    const channel = ably.channels.get(params.channelName, params.options);
+
+    const [presenceData, updatePresenceData] = useState<
+        Array<PresenceMessage<T>>
+    >([]);
 
     const updatePresence = async (message?: Types.PresenceMessage) => {
         const snapshot = await channel.presence.get();

--- a/src/hooks/useStateErrors.ts
+++ b/src/hooks/useStateErrors.ts
@@ -1,0 +1,45 @@
+import { Types } from 'ably';
+import { useState } from 'react';
+import { useConnectionStateListener } from './useConnectionStateListener';
+import { useChannelStateListener } from './useChannelStateListener';
+import { ChannelNameAndOptions, ChannelParameters } from '../AblyReactHooks';
+
+export function useStateErrors(params: ChannelNameAndOptions) {
+    const [connectionError, setConnectionError] =
+        useState<Types.ErrorInfo | null>(null);
+    const [channelError, setChannelError] = useState<Types.ErrorInfo | null>(
+        null
+    );
+
+    useConnectionStateListener(
+        ['suspended', 'failed', 'disconnected'],
+        (stateChange) => {
+            if (stateChange.reason) {
+                params.onConnectionError?.(stateChange.reason);
+                setConnectionError(stateChange.reason);
+            }
+        },
+        params.id
+    );
+
+    useConnectionStateListener(['connected', 'closed'], () => {
+        setConnectionError(null);
+    });
+
+    useChannelStateListener(
+        params,
+        ['suspended', 'failed', 'detached'],
+        (stateChange) => {
+            if (stateChange.reason) {
+                params.onChannelError?.(stateChange.reason);
+                setChannelError(stateChange.reason);
+            }
+        }
+    );
+
+    useChannelStateListener(params, ['attached'], () => {
+        setChannelError(null);
+    });
+
+    return { connectionError, channelError };
+}


### PR DESCRIPTION
Resolves #55, #20

Jira links:
- [SDK-3758](https://ably.atlassian.net/browse/SDK-3758)
- [SDK-3754](https://ably.atlassian.net/browse/SDK-3754)

The first four commits are refactors and a couple of minor fixes for the useConnectionState/useChannelState branch. The refactors include a breaking change which changes the return `useChannel` and `usePresence` hooks to an object which is more ergonomic when returning more than two values from the hooks.

The main error handling strategy, inspired by apollo, is simply to return connection/channel state errors from the hooks. As an alternative, I've also added APIs so that users may register a callback to be notified in the case of a channel/connection error. See the README changes for usage examples.

[SDK-3758]: https://ably.atlassian.net/browse/SDK-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-3754]: https://ably.atlassian.net/browse/SDK-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ