### PR TITLE
docs: update contribution guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The hooks provide a simplified syntax for interacting with Ably, and manage the 
 - [Usage](#usage)
   - [useChannel](#usechannel)
   - [usePresence](#usepresence)
-- [Developer Notes](#developer-notes)
+- [Contributing](./CONTRIBUTING.md)
 
 <!-- /code_chunk_output -->
 ---


### PR DESCRIPTION
this was pointing to a non-existent header