### PR TITLE
docs: remove outdated docs for passing in realtime instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,20 +182,6 @@ const [channel] = useChannel({ channelName: "your-channel-name", options: { ... 
 });
 ```
 
-We also support providing your own `Realtime` instance to `useChannel`, which may be useful if you need to have more than one Ably client on the same page:
-
-```javascript
-import { useChannel, Realtime } from '@ably-labs/react-hooks'
-
-const realtime = new Realtime(options);
-
-useChannel({ channelName: "your-channel-name", realtime: realtime }, (message) => {
-    ...
-})
-```
-
-for any cases where channel options must be provided (e.g. setting up encryption cypher keys).
-
 ---
 
 ### usePresence

--- a/src/AblyReactHooks.ts
+++ b/src/AblyReactHooks.ts
@@ -4,7 +4,6 @@ export type ChannelNameAndOptions = {
     channelName: string;
     options?: Types.ChannelOptions;
     id?: string;
-    realtime?: Types.RealtimePromise;
     subscribeOnly?: boolean;
 };
 


### PR DESCRIPTION
These are outdated since the new way to provide a realtime client to the library is by using the `AblyProvider` component