### PR TITLE
feat!: add React 16.8+ support for the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ This works out of the box using `create-react-app` - and you can use the package
 The latest version of this package tracks the latest version of react.
 
 | React Version | @ably-labs/react-hooks Version |
-|----------|--------|
-| >=17.0.2 |  1.1.8 |
-| >=18.1.0 |  2.0.x (current) |
+|----------|--------------------------------|
+| >=17.0.2 | 1.1.8                          |
+| >=18.1.0 | 2.x.x                          |
+| >=16.8.0 | 3.x.x (current)                |
 
 ### Ably channels and API keys
 

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
         "eslint-config-airbnb": "^19.0.4"
     },
     "peerDependencies": {
-        "react": ">=18.1.0",
-        "react-dom": ">=18.1.0"
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Resolves https://github.com/ably-labs/react-hooks/issues/64
Jira links [SDK-3779]

* added React 16.8+ support for the v3

[SDK-3779]: https://ably.atlassian.net/browse/SDK-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ