### PR TITLE
fix: using stale version of message callback for `useChannel` hook

### DIFF
--- a/src/hooks/useChannel.test.tsx
+++ b/src/hooks/useChannel.test.tsx
@@ -143,6 +143,10 @@ describe('useChannel', () => {
         expect(onConnectionError).toHaveBeenCalledTimes(1);
         expect(onConnectionError).toHaveBeenCalledWith(reason);
     });
+
+    it('should use latest version of message callback', async () => {});
+
+    it('should re-subscribe if event name has changed', async () => {});
 });
 
 const UseChannelComponentMultipleClients = () => {

--- a/src/hooks/useChannel.test.tsx
+++ b/src/hooks/useChannel.test.tsx
@@ -151,7 +151,7 @@ describe('useChannel', () => {
 
             useChannel('blah', () => {
                 callbackCount++;
-                setCount((prev) => prev + 1);
+                setCount(count + 1);
             });
 
             return <div role="counter">{count}</div>;
@@ -161,6 +161,9 @@ describe('useChannel', () => {
 
         await act(async () => {
             ablyClient.channels.get('blah').publish({ text: 'test message 1' });
+        });
+
+        await act(async () => {
             ablyClient.channels.get('blah').publish({ text: 'test message 2' });
         });
 

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -56,7 +56,7 @@ export function useChannel(
         useStateErrors(channelHookOptions);
 
     useEffect(() => {
-        if (channelOptionsRef.current !== channelOptions) {
+        if (channelOptionsRef.current !== channelOptions && channelOptions) {
             channel.setOptions(channelOptions);
         }
         channelOptionsRef.current = channelOptions;
@@ -68,7 +68,8 @@ export function useChannel(
 
     useEffect(() => {
         const listener: AblyMessageCallback = (message) => {
-            ablyMessageCallbackRef.current(message);
+            ablyMessageCallbackRef.current &&
+                ablyMessageCallbackRef.current(message);
         };
 
         const subscribeArgs: SubscribeArgs =


### PR DESCRIPTION
Resolves https://github.com/ably-labs/react-hooks/issues/19
Jira links [SDK-3755]

[SDK-3755]: https://ably.atlassian.net/browse/SDK-3755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ